### PR TITLE
Bugfix & tiled_ssim(..)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
+dist
 *.egg-info

--- a/camp_zipnerf/internal/image_utils.py
+++ b/camp_zipnerf/internal/image_utils.py
@@ -126,3 +126,15 @@ class MetricHarness:
 
     # Apply the name function and cast all metrics down to a scalar float.
     return {name_fn(k): float(v) for (k, v) in metrics.items()}
+
+
+def tiled_ssim(a, b, **kwargs):
+  """Compute SSIMs on a stack of image tiles of size (..., x, y, c)."""
+  # Instead of the usual SSIM, which convolves with a Gaussian blur and returns
+  # the average SSIM of each pixel, here we're just using the average of the
+  # whole patch as the blur function. This gives us a cheap tile-based SSIM
+  # alternative that behaves similarly to SSIM with a box filter evaluated
+  # only once per patch.
+  filter_fn = lambda z: jnp.mean(z, axis=[-3, -2], keepdims=True)
+  return dm_pix.ssim(a, b, filter_fn=filter_fn, **kwargs)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "camp_zipnerf"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
     "chex==0.1.85",
     "dm-pix==0.4.2",
@@ -33,6 +33,7 @@ description = "Official implementation of Zip-NeRF."
 license = {file = "LICENSE"}
 readme = "README.md"
 
-[tool.setuptools]
-packages = ["camp_zipnerf"]  # only publish one folder: "camp_zipnerf"
+[tool.setuptools.packages.find]
+where = [""]
+include = ["camp_zipnerf*"]  # only publish one folder: "camp_zipnerf"
 


### PR DESCRIPTION
This PR introduces three changes,

1. It fixes an issue where the following command would fail to install the contents of `camp_zipnerf/internal`,

```
python3 -m pip install git+https://github.com/jonbarron/camp_zipnerf.git
```

This issue has no effect on users cloning this directory directly.

2. It adds the `tiled_ssim(..)` function.
3. It bumps the version number to `0.0.2`.