### PR TITLE
Bump dependency version: tensorflow and numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
     "jaxlib==0.4.23",
     "mediapy==1.2.0",
     "ml_collections",
-    "numpy==1.26.3",
+    "numpy==1.26.4",
     "opencv-python==4.9.0.80",
     "pillow==10.2.0",
     "rawpy==0.19.0",
     "scipy==1.11.0",
     "tensorboard==2.15.1",
-    "tensorflow==2.15.0.post1",
+    "tensorflow==2.15.1",
 ]
 authors = [
     {name = "Jonathan T. Barron"},


### PR DESCRIPTION
Bump each by 0.0.1. This has no effect on this repo but will help a downstream library I'm working on.